### PR TITLE
Remove duplicate read of value in sqlite-mode-extras-edit-row-field

### DIFF
--- a/sqlite-mode-extras.el
+++ b/sqlite-mode-extras.el
@@ -163,10 +163,7 @@ Takes TABLE to query and COLUMN to select from for completions."
                                               nil
                                               (sqlite-mode-extras--row-field-value-at-point)))
                          (read-string (format "%s: " column)
-                                      (sqlite-mode-extras--row-field-value-at-point)))
-
-                       (read-string (format "%s: " column)
-                                    (sqlite-mode-extras--row-field-value-at-point)))))
+                                      (sqlite-mode-extras--row-field-value-at-point))))))
     (unless (string-equal (car (seq-first columns)) "id")
       (error "First column must be 'id'"))
     (sqlite-execute


### PR DESCRIPTION
Currently, `sqlite-mode-extras-edit-row-field` will prompt twice for new non-numeric values, only using the last value for updating the field.

The read of non-numeric values is already done in the body of `(if sqlite-mode-extras-auto-complete-enabled ..)` (either using completion or directly). The following read-string is obsolete and currently overwrites any selection from the completing-read.